### PR TITLE
Yang models for static route support on south-ocnos

### DIFF
--- a/yang/goldstone-nexthop.yang
+++ b/yang/goldstone-nexthop.yang
@@ -1,0 +1,128 @@
+module goldstone-nexthop {
+
+  yang-version "1";
+
+  namespace "http://goldstone.net/yang/goldstone-nexthop";
+  prefix gs-nexthop;
+
+  import goldstone-interfaces { prefix gs-if; }
+  import goldstone-routing { prefix gs-rt; }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  organization
+    "GoldStone";
+
+  description
+    "Goldstone Nexthop";
+
+  revision 2022-12-14 {
+    description
+      "Initial revision.";
+  }
+
+  typedef blackhole-type {
+    type enumeration {
+      enum "unspec" {
+        description
+          "Generic unreachable.";
+      }
+      enum "null" {
+        description
+          "Null type.";
+      }
+      enum "reject" {
+        description
+          "ICMP unreachable.";
+      }
+      enum "prohibited" {
+        description
+          "ICMP admin-prohibited.";
+      }
+    }
+    default "null";
+    description
+      "Nexthop blackhole types.";
+  }
+
+  grouping nexthop-config {
+    leaf index {
+      type uint32;
+      description
+        "An user-specified identifier utilised to uniquely reference
+        the next-hop entry in the next-hop list.";
+    }
+
+    leaf gateway {
+      type inet:ipv4-address;
+      description
+        "The nexthop gateway address.";
+    }
+
+    leaf interface {
+      type gs-if:interface-ref;
+      description
+        "The nexthop egress interface.";
+    }
+
+    leaf distance {
+      type gs-rt:administrative-distance;
+      description
+        "Admin distance associated with this route.";
+    }
+
+    leaf blackhole-type {
+      type blackhole-type;
+      description
+        "A blackhole sub-type, if the nexthop is a blackhole type.";
+    }
+
+    leaf onlink {
+      type boolean;
+      default "false";
+      description
+        "Nexthop is directly connected.";
+    }
+  }
+
+  grouping nexthop-state {
+    leaf active {
+      type boolean;
+      description
+        "Nexthop is active.";
+    }
+
+    leaf fib {
+      type boolean;
+      description
+        "Nexthop is installed in fib.";
+    }
+  }
+
+  grouping nexthops-top {
+    container nexthops {
+      list nexthop {
+        key "index";
+        description
+          "A list of nexthop objects.";
+
+        leaf index {
+          type leafref {
+            path "../config/index";
+          }
+        }
+
+        container config {
+          uses nexthop-config;
+        }
+        container state {
+          config false;
+          uses nexthop-config;
+          uses nexthop-state;
+        }
+      }
+    }
+  }
+}

--- a/yang/goldstone-routing.yang
+++ b/yang/goldstone-routing.yang
@@ -1,0 +1,71 @@
+module goldstone-routing {
+
+  yang-version "1";
+
+  namespace "http://goldstone.net/yang/goldstone-routing";
+  prefix gs-routing;
+
+  organization
+    "GoldStone";
+
+  contact
+    "Goldstone";
+
+  description
+    "Goldstone Routing";
+
+  revision 2022-12-14 {
+    description
+      "Initial revision.";
+  }
+
+  typedef control-plane-protocol {
+    type enumeration {
+      enum STATIC;
+    }
+  }
+
+  typedef administrative-distance {
+    type uint8 {
+      range "1..255";
+    }
+    description
+      "Admin distance associated with the route.";
+  }
+
+  grouping routing-config {
+    description
+      "Configuration data nodes common to the routing
+      subsystems";
+
+    leaf type {
+      type control-plane-protocol;
+      description
+        "Type of the control-plane protocol";
+    }
+
+    leaf name {
+      type string;
+      description
+        "An arbitrary name of the control-plane protocol
+         instance.";
+    }
+  }
+
+  grouping routing-state {
+  }
+
+  container routing {
+    description
+      "Configuration parameters for the routing subsystem.";
+
+    container config {
+      uses routing-config;
+    }
+    container state {
+      config false;
+      uses routing-config;
+      uses routing-state;
+    }
+  }
+}

--- a/yang/goldstone-static-route.yang
+++ b/yang/goldstone-static-route.yang
@@ -1,0 +1,80 @@
+module goldstone-static-route {
+
+  yang-version "1";
+
+  namespace "http://goldstone.net/yang/goldstone-static-route";
+  prefix gs-static-route;
+
+  import goldstone-routing {
+    prefix gs-rt;
+  }
+
+  import goldstone-nexthop {
+    prefix nexthop;
+  }
+
+  import ietf-inet-types {
+    prefix inet;
+  }
+
+  organization
+    "GoldStone";
+
+  description
+    "This module contains a collection of YANG definitions for
+    managing and configuring static route";
+
+  revision 2022-12-14 {
+    description
+      "Initial revision.";
+  }
+
+  grouping static-route-config {
+    description
+      "Configuration data for static routes.";
+
+    leaf prefix {
+      type inet:ipv4-prefix;
+      description
+        "Destination IPv4 prefix for the static route";
+    }
+  }
+
+  grouping static-route-state {
+  }
+
+  augment "/gs-rt:routing" {
+    container static-route {
+      when "../gs-rt:config/gs-rt:type = 'STATIC'" {
+        description
+          "This container is only valid for the static routing
+           protocol in goldstone.";
+      }
+      description
+        "List of configured static routes";
+
+      list route-list {
+        key "prefix";
+        description
+          "List of configured static routes";
+
+        leaf prefix {
+          type leafref {
+            path "../config/prefix";
+          }
+        }
+
+        container config {
+          uses static-route-config;
+        }
+        container state {
+          config false;
+          uses static-route-config;
+          uses static-route-state;
+        }
+
+        uses nexthop:nexthops-top;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds new yang models of `goldstone-routing`, `goldstone-static-route`, and `goldstone-nexthop` to support static route on `south-ocnos`.
As discussed in [issue 70](https://github.com/oopt-goldstone/goldstone-mgmt/issues/70), these models are defined considering the followings:

- These models are based on [FRR yang models](https://github.com/FRRouting/frr/tree/master/yang) since `south-frr` will be introduced in the future https://github.com/oopt-goldstone/goldstone-mgmt/issues/50.
- The models should have extensibility to support other routing protocols such as OSPFv2 although the first target is static-route.
  - Only necessary attributes for static-route are defined in this phase.
  - `vrf` is not considered in proposed model since the concept of network-instance has not been introduced in goldstone.

In addition to these three models, we may need another yang model which represents consolidated active routes in the system like RIB/FIB.
In FRR, such structure is introduced [here](https://github.com/FRRouting/frr/blob/master/yang/frr-zebra.yang#L598-L647), but corresponding model has not been introduced yet.
We may need to decide if we had better to add such structure in current phase (of targeting on static-route support as the first step).

@ishidawataru @ipi-claytonpascoal
Could you please review the models, and continue to discuss the above?