### PR TITLE
docker: fixed to copy patched openroadm models to base image

### DIFF
--- a/docker/agent.Dockerfile
+++ b/docker/agent.Dockerfile
@@ -23,13 +23,19 @@ RUN --mount=type=bind,from=builder,source=/usr/share/debs/sysrepo,target=/src ls
 RUN --mount=type=bind,from=builder,source=/usr/share/wheels,target=/usr/share/wheels \
             pip install /usr/share/wheels/libyang/*.whl /usr/share/wheels/sysrepo/*.whl
 
+RUN --mount=type=bind,source=sm/openroadm,target=/root/sm/openroadm,rw \
+    --mount=type=bind,source=patches/openroadm,target=/root/patches \
+    --mount=type=tmpfs,target=/root/.pc,rw \
+    cd /root && quilt upgrade && quilt push -a && \
+    mkdir -p /var/lib/goldstone/yang/or && \
+    cp -r /root/sm/openroadm/model/* /var/lib/goldstone/yang/or/
+
 COPY yang /var/lib/goldstone/yang/gs/
 ENV GS_YANG_REPO /var/lib/goldstone/yang/gs
 COPY sm/openconfig/release/models/ /var/lib/goldstone/yang/oc/
 ENV OC_YANG_REPO /var/lib/goldstone/yang/oc
 COPY sm/openconfig/third_party/ietf/ /var/lib/goldstone/yang/ietf
 ENV IETF_YANG_REPO /var/lib/goldstone/yang/ietf
-COPY sm/openroadm/model /var/lib/goldstone/yang/or/
 ENV OR_YANG_REPO /var/lib/goldstone/yang/or
 
 RUN --mount=type=bind,source=scripts,target=/src \
@@ -296,12 +302,6 @@ RUN --mount=type=bind,source=scripts/,target=/scripts,rw cp /scripts/operational
 #---
 
 FROM base AS xlate-or
-
-RUN --mount=type=bind,source=sm/openroadm,target=/root/sm/openroadm,rw \
-    --mount=type=bind,source=patches/openroadm,target=/root/patches \
-    --mount=type=tmpfs,target=/root/.pc,rw \
-    cd /root && quilt upgrade && quilt push -a && \
-    cp -r /root/sm/openroadm/model/* /var/lib/goldstone/yang/or
 
 RUN --mount=type=bind,source=src/xlate/openroadm,target=/src,rw pip install /src
 


### PR DESCRIPTION
This PR fixes to copy patched openroadm models to base image, not to xlate-or image, as the other models do.
Because `south-onlp` is [used as YANG_CONTAINER during image build](https://github.com/oopt-goldstone/goldstone-buildimage/blob/master/packages/base/any/mgmt/builds/Makefile#L9), the patched models should be in base image.